### PR TITLE
upgrade to go 1.24

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -1,8 +1,8 @@
 module github.com/opslevel/opslevel-mcp
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.4
+toolchain go1.24.2
 
 require (
 	github.com/mark3labs/mcp-go v0.21.0


### PR DESCRIPTION
Resolves #

### Problem

The maturity check for uses latest golang was failing.

### Solution

Ran

```bash
go mod tidy -go=1.24
```

To update the go version and toolchain

### Checklist

- [x] I have run this code, and it appears to resolve the stated issue.
- [x] This PR has no user interface changes or has already received approval from product management to change the interface.
- [x] Make a [changie](https://github.com/OpsLevel/opslevel-mcp/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change.
