### PR TITLE
Give the AI a little more context on when to use this tool and make it fully dynamic

### DIFF
--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -174,7 +174,7 @@ var rootCmd = &cobra.Command{
 			mcp.NewTool(
 				"resourceDetails",
 				mcp.WithDescription(fmt.Sprintf("Get details for a single resource (%s) in an OpsLevel account using its ID or alias.", strings.Join(opslevel.AllAliasOwnerTypeEnum, ","))),
-				mcp.WithString("resourceType", mcp.Required(), mcp.Description("The type of the resource."), mcp.Enum("service", "infrastructure_resource", "team", "system", "domain")),
+				mcp.WithString("resourceType", mcp.Required(), mcp.Description("The type of the resource."), mcp.Enum(opslevel.AllAliasOwnerTypeEnum...)),
 				mcp.WithString("identifier", mcp.Required(), mcp.Description("The ID or alias of the resource.")),
 			),
 			func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {


### PR DESCRIPTION
Resolves #

### Problem

The list of resources to target is dynamic and the way its coded right now means expansions are not automatically picked up.

### Solution

Use the `All*` enum arrays to make this code future proof

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/opslevel-mcp/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change.
