### PR TITLE
fix dockerfile for smithery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ RUN apk add --no-cache ca-certificates
 
 COPY --from=public.ecr.aws/opslevel/mcp:latest /usr/local/bin/opslevel-mcp /bin/opslevel-mcp
 
-ENTRYPOINT ["/opslevel-mcp"]
+ENTRYPOINT ["/bin/opslevel-mcp"]


### PR DESCRIPTION
Resolves #

### Problem

The image for smithery doesn't work

```
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: exec: "/opslevel-mcp": stat /opslevel-mcp: no such file or directory: unknown

Run 'docker run --help' for more information
```

### Solution

Use the actual location of the binary copied out of the aws image

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/opslevel-mcp/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change.
