### PR TITLE
Add install instructions for windsurf

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,28 @@ Currently, the MCP server only uses read-only access to your OpsLevel account an
 }
 ```
 
+## Windsurf
+
+[Windsurf](https://docs.cursor.com/context/model-context-protocol)
+
+1. Navigate to Windsurf - Settings > Advanced Settings
+2. Scroll down to the Cascade section and you will find the option to add a new server
+3. Edit the [mpc_config.json](https://docs.windsurf.com/windsurf/mcp#mcp-config-json) with the below configuration
+4. Restart Windsurf
+
+```json
+{
+  "mcpServers": {
+    "opslevel": {
+      "command": "opslevel-mcp",  
+      "env": {
+        "OPSLEVEL_API_TOKEN": "XXXXXX"
+      }
+    }
+  }
+}
+```
+
 ### Docker
 
 If you didn't install the binary directly and instead pulled the docker image you'll need to adjust the above MCP configurations to support running the server via docker


### PR DESCRIPTION
Resolves #

### Problem

We don't have install instructions for windsurf

### Solution

I found instructions for windsurf on the cloudflare MCP - adding them to ours

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/opslevel-mcp/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change.
