### PR TITLE
Populate Properties

### DIFF
--- a/.changes/unreleased/Added-20250502-124142.yaml
+++ b/.changes/unreleased/Added-20250502-124142.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Ensure that tool 'resourceDetails' populates the properties defined on a service
+time: 2025-05-02T12:41:42.102546-05:00

--- a/.changes/unreleased/Added-20250502-124142.yaml
+++ b/.changes/unreleased/Added-20250502-124142.yaml
@@ -1,3 +1,3 @@
 kind: Added
-body: Ensure that tool 'resourceDetails' populates the properties defined on a service
+body: Ensure that tool 'resourceDetails' populates the properties defined on a component
 time: 2025-05-02T12:41:42.102546-05:00

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -181,7 +181,13 @@ var rootCmd = &cobra.Command{
 				identifier := req.Params.Arguments["identifier"].(string)
 				resourceType := opslevel.AliasOwnerTypeEnum(resourceTypeString)
 				resp, err := client.GetAliasableResource(resourceType, identifier)
-				return newToolResult(resp, err)
+				switch v := resp.(type) {
+				case *opslevel.Service:
+					v.Properties, err = v.GetProperties(client, nil)
+					return newToolResult(v, err)
+				default:
+					return newToolResult(resp, err)
+				}
 			})
 
 		// Register all documents, filtered by search term


### PR DESCRIPTION
Resolves #

### Problem

A prompt like the following
```
Can you tell me what's the value of "Release Strategy" for my "service-alias" component in opslevel?
```
Nets the following response from the AI
```
I apologize, but I wasn't able to find the specific "Release Strategy" value for your "service-alias" component in OpsLevel.

The "Release Strategy" information might be stored in one of these places:

In a custom property field that wasn't visible in my queries
In documentation associated with the service
In configuration files in the repository itself

Would you like me to try a different approach to find this information?
```

### Solution

This is because properties are an "add on" call that needs to be made.  The reason for this was to keep the `client.ListServices` function more lightweight because its already quite heavy.

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/opslevel-mcp/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change.
