### PR TITLE
Add readonly/idempotent annotations to all tools

### DIFF
--- a/.changes/unreleased/Changed-20250507-102631.yaml
+++ b/.changes/unreleased/Changed-20250507-102631.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Set correct readonly / nondestructive annotation on tools
+time: 2025-05-07T10:26:31.463409-04:00

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -71,8 +71,17 @@ var rootCmd = &cobra.Command{
 
 		// Register Teams
 		s.AddTool(
-			mcp.NewTool("teams",
-				mcp.WithDescription("Get all the team names, identifiers and metadata for the opslevel account.  Teams are owners of other objects in opslevel. Only use this if you need to search all teams.")),
+			mcp.NewTool(
+				"teams",
+				mcp.WithDescription("Get all the team names, identifiers and metadata for the OpsLevel account.  Teams are owners of other objects in OpsLevel. Only use this if you need to search all teams."),
+				mcp.WithToolAnnotation(mcp.ToolAnnotation{
+					Title:           "Teams in OpsLevel",
+					ReadOnlyHint:    true,
+					DestructiveHint: false,
+					IdempotentHint:  true,
+					OpenWorldHint:   true,
+				}),
+			),
 			func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 				resp, err := client.ListTeams(nil)
 				return newToolResult(resp.Nodes, err)
@@ -80,7 +89,17 @@ var rootCmd = &cobra.Command{
 
 		// Register Users
 		s.AddTool(
-			mcp.NewTool("users", mcp.WithDescription("Get all the user names, e-mail addresses and metadata for the opslevel account.  Users are the people in opslevel. Only use this if you need to search all users.")),
+			mcp.NewTool(
+				"users",
+				mcp.WithDescription("Get all the user names, e-mail addresses and metadata for the OpsLevel account.  Users are the people in OpsLevel. Only use this if you need to search all users."),
+				mcp.WithToolAnnotation(mcp.ToolAnnotation{
+					Title:           "Users in OpsLevel",
+					ReadOnlyHint:    true,
+					DestructiveHint: false,
+					IdempotentHint:  true,
+					OpenWorldHint:   true,
+				}),
+			),
 			func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 				resp, err := client.ListUsers(nil)
 				return newToolResult(resp.Nodes, err)
@@ -88,7 +107,18 @@ var rootCmd = &cobra.Command{
 
 		// Register Actions
 		s.AddTool(
-			mcp.NewTool("actions", mcp.WithDescription("Get all the information about actions the user can run in the opslevel account")),
+			mcp.NewTool(
+				"actions",
+				mcp.WithDescription("Get all the information about actions the user can run in the OpsLevel account"),
+
+				mcp.WithToolAnnotation(mcp.ToolAnnotation{
+					Title:           "Actions in OpsLevel",
+					ReadOnlyHint:    true,
+					DestructiveHint: false,
+					IdempotentHint:  true,
+					OpenWorldHint:   true,
+				}),
+			),
 			func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 				resp, err := client.ListTriggerDefinitions(nil)
 				return newToolResult(resp.Nodes, err)
@@ -96,7 +126,18 @@ var rootCmd = &cobra.Command{
 
 		// Register Filters
 		s.AddTool(
-			mcp.NewTool("filters", mcp.WithDescription("Get all the rubric filter names and which predicates they have for the opslevel account")),
+			mcp.NewTool(
+				"filters",
+				mcp.WithDescription("Get all the rubric filter names and which predicates they have for the OpsLevel account"),
+
+				mcp.WithToolAnnotation(mcp.ToolAnnotation{
+					Title:           "Filters in OpsLevel",
+					ReadOnlyHint:    true,
+					DestructiveHint: false,
+					IdempotentHint:  true,
+					OpenWorldHint:   true,
+				}),
+			),
 			func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 				resp, err := client.ListFilters(nil)
 				return newToolResult(resp.Nodes, err)
@@ -104,7 +145,17 @@ var rootCmd = &cobra.Command{
 
 		// Register Components
 		s.AddTool(
-			mcp.NewTool("components", mcp.WithDescription("Get all the components in the opslevel account.  Components are objects in opslevel that represent things like apis, libraries, services, frontends, backends, etc.")),
+			mcp.NewTool(
+				"components",
+				mcp.WithDescription("Get all the components in the OpsLevel account.  Components are objects in OpsLevel that represent things like apis, libraries, services, frontends, backends, etc."),
+				mcp.WithToolAnnotation(mcp.ToolAnnotation{
+					Title:           "Components in OpsLevel",
+					ReadOnlyHint:    true,
+					DestructiveHint: false,
+					IdempotentHint:  true,
+					OpenWorldHint:   true,
+				}),
+			),
 			func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 				resp, err := client.ListServices(nil)
 				if err != nil {
@@ -124,7 +175,17 @@ var rootCmd = &cobra.Command{
 
 		// Register Infra
 		s.AddTool(
-			mcp.NewTool("infrastructure", mcp.WithDescription("Get all the infrastructure in the opslevel account.  Infrastructure are objects in opslevel that represent cloud provider resources like vpc, databases, caches, networks, vms, etc.")),
+			mcp.NewTool(
+				"infrastructure",
+				mcp.WithDescription("Get all the infrastructure in the OpsLevel account.  Infrastructure are objects in OpsLevel that represent cloud provider resources like vpc, databases, caches, networks, vms, etc."),
+				mcp.WithToolAnnotation(mcp.ToolAnnotation{
+					Title:           "Infrastructure in OpsLevel",
+					ReadOnlyHint:    true,
+					DestructiveHint: false,
+					IdempotentHint:  true,
+					OpenWorldHint:   true,
+				}),
+			),
 			func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 				resp, err := client.ListInfrastructure(nil)
 				if err != nil {
@@ -146,11 +207,17 @@ var rootCmd = &cobra.Command{
 
 		// Register Domains
 		s.AddTool(
-			mcp.NewTool("domains", mcp.WithDescription(
-				`Get all the domains in the opslevel account.
-			Domains are comprised of child Systems which contain Components.
-			Used to represent large business units or verticals within OpsLevel.
-			`)),
+			mcp.NewTool(
+				"domains",
+				mcp.WithDescription("Get all the domains in the OpsLevel account. Domains are comprised of child Systems which contain Components. Used to represent large business units or verticals within OpsLevel."),
+				mcp.WithToolAnnotation(mcp.ToolAnnotation{
+					Title:           "Domains in OpsLevel",
+					ReadOnlyHint:    true,
+					DestructiveHint: false,
+					IdempotentHint:  true,
+					OpenWorldHint:   true,
+				}),
+			),
 			func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 				resp, err := client.ListDomains(nil)
 				return newToolResult(resp.Nodes, err)
@@ -158,11 +225,17 @@ var rootCmd = &cobra.Command{
 
 		// Register Systems
 		s.AddTool(
-			mcp.NewTool("systems", mcp.WithDescription(
-				`Get all the systems in the opslevel account. 
-			Systems are made up of Components that combine to form a unified whole or function.
-			eg a “Checkout” System that combines a cart and payment component.
-			`)),
+			mcp.NewTool(
+				"systems",
+				mcp.WithDescription("Get all the systems in the OpsLevel account. Systems are made up of Components that combine to form a unified whole or function. eg a 'Checkout' System that combines a cart and payment component."),
+				mcp.WithToolAnnotation(mcp.ToolAnnotation{
+					Title:           "Systems in OpsLevel",
+					ReadOnlyHint:    true,
+					DestructiveHint: false,
+					IdempotentHint:  true,
+					OpenWorldHint:   true,
+				}),
+			),
 			func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 				resp, err := client.ListSystems(nil)
 				return newToolResult(resp.Nodes, err)
@@ -175,6 +248,13 @@ var rootCmd = &cobra.Command{
 				mcp.WithDescription(fmt.Sprintf("Get details for a single resource (%s) in an OpsLevel account using its ID or alias.", strings.Join(opslevel.AllAliasOwnerTypeEnum, ","))),
 				mcp.WithString("resourceType", mcp.Required(), mcp.Description("The type of the resource."), mcp.Enum(opslevel.AllAliasOwnerTypeEnum...)),
 				mcp.WithString("identifier", mcp.Required(), mcp.Description("The ID or alias of the resource.")),
+				mcp.WithToolAnnotation(mcp.ToolAnnotation{
+					Title:           "Resource Details in OpsLevel",
+					ReadOnlyHint:    true,
+					DestructiveHint: false,
+					IdempotentHint:  true,
+					OpenWorldHint:   true,
+				}),
 			),
 			func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 				resourceTypeString := req.Params.Arguments["resourceType"].(string)
@@ -193,8 +273,15 @@ var rootCmd = &cobra.Command{
 		// Register all documents, filtered by search term
 		s.AddTool(
 			mcp.NewTool("documents",
-				mcp.WithDescription("Get all the documents for the opslevel account. Documents are filterable by search term. Documents could be things like runbooks, integration documentation, api documentation, readme's, or other forms of documentation."),
+				mcp.WithDescription("Get all the documents for the OpsLevel account. Documents are filterable by search term. Documents could be things like runbooks, integration documentation, api documentation, readme's, or other forms of documentation."),
 				mcp.WithString("searchTerm", mcp.Description("To filter documents with.")),
+				mcp.WithToolAnnotation(mcp.ToolAnnotation{
+					Title:           "Documents in OpsLevel",
+					ReadOnlyHint:    true,
+					DestructiveHint: false,
+					IdempotentHint:  true,
+					OpenWorldHint:   true,
+				}),
 			),
 			func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 				searchTerm := ""
@@ -209,8 +296,15 @@ var rootCmd = &cobra.Command{
 		// Register document by id
 		s.AddTool(
 			mcp.NewTool("document",
-				mcp.WithDescription("Get the contents of a technical or api document in the opslevel account, specified by document 'id' or the 'preferredApiDocument' (on a component). Documents could be things like runbooks, integration documentation, api documentation, readme's, or other forms of documentation."),
+				mcp.WithDescription("Get the contents of a technical or api document in the OpsLevel account, specified by document 'id' or the 'preferredApiDocument' (on a component). Documents could be things like runbooks, integration documentation, api documentation, readme's, or other forms of documentation."),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The id of the document to fetch.")),
+				mcp.WithToolAnnotation(mcp.ToolAnnotation{
+					Title:           "Document in OpsLevel",
+					ReadOnlyHint:    true,
+					DestructiveHint: false,
+					IdempotentHint:  true,
+					OpenWorldHint:   true,
+				}),
 			),
 			func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 				id := req.Params.Arguments["id"].(string)
@@ -221,9 +315,16 @@ var rootCmd = &cobra.Command{
 		// Register all documents, filtered by service id and search term
 		s.AddTool(
 			mcp.NewTool("documentsOnService",
-				mcp.WithDescription("Get all documents on a specified service for the opslevel account, specified by service id and filtered by search term. Documents could be things like runbooks, integration documentation, api documentation, readme's, or other forms of documentation."),
+				mcp.WithDescription("Get all documents on a specified service for the OpsLevel account, specified by service id and filtered by search term. Documents could be things like runbooks, integration documentation, api documentation, readme's, or other forms of documentation."),
 				mcp.WithString("serviceId", mcp.Required(), mcp.Description("The id of the service which the documents are on.")),
 				mcp.WithString("searchTerm", mcp.Description("To filter documents with.")),
+				mcp.WithToolAnnotation(mcp.ToolAnnotation{
+					Title:           "Documents for Service in OpsLevel",
+					ReadOnlyHint:    true,
+					DestructiveHint: false,
+					IdempotentHint:  true,
+					OpenWorldHint:   true,
+				}),
 			),
 			func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 				service := opslevel.Service{


### PR DESCRIPTION
https://modelcontextprotocol.io/docs/concepts/tools#tool-definition-structure

There are optional annotations you can apply to tools, and by default mcp-go sets `DestructiveHint` to true. Since all our tools are non-destructive, readonly and idempotent set those.

I also added tool titles and fixed the casing on OpsLevel in tool descriptions.

### Testing

```
npx @modelcontextprotocol/inspector --config mcp_configs.json --server opslevel --cli --method tools/list
```
#### Old

```json
{
  "tools": [
    {
      "name": "actions",
      "description": "Get all the information about actions the user can run in the opslevel account",
      "inputSchema": {
        "type": "object"
      },
      "annotations": {
        "destructiveHint": true,
        "openWorldHint": true
      }
    },
    {
      "name": "components",
      "description": "Get all the components in the opslevel account.  Components are objects in opslevel that represent things like apis, libraries, services, frontends, backends, etc.",
      "inputSchema": {
        "type": "object"
      },
      "annotations": {
        "destructiveHint": true,
        "openWorldHint": true
      }
    },
...
```

#### New

```json
{
  "tools": [
    {
      "name": "actions",
      "description": "Get all the information about actions the user can run in the opslevel account",
      "inputSchema": {
        "type": "object"
      },
      "annotations": {
        "title": "OpsLevel Actions",
        "readOnlyHint": true,
        "idempotentHint": true,
        "openWorldHint": true
      }
    },
    {
      "name": "components",
      "description": "Get all the components in the opslevel account.  Components are objects in opslevel that represent things like apis, libraries, services, frontends, backends, etc.",
      "inputSchema": {
        "type": "object"
      },
      "annotations": {
        "title": "OpsLevel Components",
        "readOnlyHint": true,
        "idempotentHint": true,
        "openWorldHint": true
      }
    },
...
```

### Checklist

- [x] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [x] Make a [changie](https://github.com/OpsLevel/opslevel-mcp/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change.
