### PR TITLE
populate last deploy into the MCP data for a component

### DIFF
--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -263,8 +264,11 @@ var rootCmd = &cobra.Command{
 				resp, err := client.GetAliasableResource(resourceType, identifier)
 				switch v := resp.(type) {
 				case *opslevel.Service:
-					v.Properties, err = v.GetProperties(client, nil)
-					return newToolResult(v, err)
+					lastDeploy, err1 := v.GetLastDeploy(client, nil)
+					properties, err2 := v.GetProperties(client, nil)
+					v.LastDeploy = lastDeploy
+					v.Properties = properties
+					return newToolResult(v, errors.Join(err1, err2))
 				default:
 					return newToolResult(resp, err)
 				}


### PR DESCRIPTION
Resolves #

### Problem

The `resourceDetails` tool doesn't have the last deploy data

### Solution

Add this to opslevel-go and plumb through MCP

Depends on - https://github.com/OpsLevel/opslevel-go/pull/545

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/opslevel-mcp/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change.
