### PR TITLE
include Language and Framework in components list tool

### DIFF
--- a/.changes/unreleased/Added-20250527-074111.yaml
+++ b/.changes/unreleased/Added-20250527-074111.yaml
@@ -1,0 +1,4 @@
+kind: Added
+body: Add Language & Framework to the components tool directly, so it is listed without
+  additional calls to `resourceDetails`
+time: 2025-05-27T07:41:11.365169-07:00

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -27,6 +27,8 @@ type serializedComponent struct {
 	Id    string
 	Name  string
 	Owner string
+	Language string
+	Framework string
 	Url   string
 }
 
@@ -185,6 +187,8 @@ var rootCmd = &cobra.Command{
 						Id:    string(node.Id),
 						Name:  node.Name,
 						Owner: node.Owner.Alias,
+						Language: node.Language,
+						Framework: node.Framework,
 						Url:   node.HtmlURL,
 					})
 				}

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -24,12 +24,12 @@ import (
 var defaultSystemPrompt string
 
 type serializedComponent struct {
-	Id    string
-	Name  string
-	Owner string
-	Language string
+	Id        string
 	Framework string
-	Url   string
+	Language  string
+	Name      string
+	Owner     string
+	Url       string
 }
 
 type serializedInfrastructureResource struct {
@@ -167,7 +167,7 @@ var rootCmd = &cobra.Command{
 		s.AddTool(
 			mcp.NewTool(
 				"components",
-				mcp.WithDescription("Get all the components in the OpsLevel account.  Components are objects in OpsLevel that represent things like apis, libraries, services, frontends, backends, etc."),
+				mcp.WithDescription("Get all the components in the OpsLevel account.  Components are objects in OpsLevel that represent things like apis, libraries, services, frontends, backends, etc. Use this tool to list what components are in the catalog, what team is the owner, what primary coding language is used, and what primary framework is used."),
 				mcp.WithToolAnnotation(mcp.ToolAnnotation{
 					Title:           "Components in OpsLevel",
 					ReadOnlyHint:    true,
@@ -184,12 +184,12 @@ var rootCmd = &cobra.Command{
 				var components []serializedComponent
 				for _, node := range resp.Nodes {
 					components = append(components, serializedComponent{
-						Id:    string(node.Id),
-						Name:  node.Name,
-						Owner: node.Owner.Alias,
-						Language: node.Language,
+						Id:        string(node.Id),
+						Name:      node.Name,
+						Owner:     node.Owner.Alias,
+						Language:  node.Language,
 						Framework: node.Framework,
-						Url:   node.HtmlURL,
+						Url:       node.HtmlURL,
 					})
 				}
 				return newToolResult(components, nil)


### PR DESCRIPTION
Resolves #

### Problem

Queries like "List all services written in Ruby and give me their owners" do not work, because it requires a call to `resourceDetails` for every single resource.
Language and Framework are pretty lightweight and the additional context isn't going to harm results.

### Solution
Include language & framework in the components tool directly, so that 100s of `resourceDetails` requests aren't needed.
<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/opslevel-mcp/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change.


<img width="586" alt="Screenshot 2025-05-27 at 7 41 27 AM" src="https://github.com/user-attachments/assets/8e78bd51-2f70-4993-a206-d50059246945" />


