### PR TITLE
Add campaigns tool

### DIFF
--- a/.changes/unreleased/Added-20250613-100609.yaml
+++ b/.changes/unreleased/Added-20250613-100609.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add campaigns tool for listing campaigns
+time: 2025-06-13T10:06:09.286358-03:00

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -534,7 +534,7 @@ var rootCmd = &cobra.Command{
 			mcp.NewTool(
 				"campaigns",
 				mcp.WithDescription("Get all the campaigns in the OpsLevel account. Campaigns are used to track and manage initiatives or projects within OpsLevel."),
-				mcp.WithString("status", mcp.Description("Filter campaigns by status"), mcp.Enum(opslevel.AllCampaignStatusEnum...)),
+				mcp.WithString("status", mcp.Description("Filter campaigns by status, default is 'in_progress'"), mcp.Enum(opslevel.AllCampaignStatusEnum...)),
 				mcp.WithToolAnnotation(mcp.ToolAnnotation{
 					Title:           "Campaigns in OpsLevel",
 					ReadOnlyHint:    &trueValue,


### PR DESCRIPTION
Expose campaigns (without checks) as a new tool. Default filter only shows in progress campaigns


### Problem

Users of the mcp server can't see what campaigns exist in opslevel

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

Add a tool to list campaigns in opslevel!

Doesn't include a way to see campaigns for a particular service and it doesn't show the details of the checks yet

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [x] Make a [changie](https://github.com/OpsLevel/opslevel-mcp/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change.
