### PR TITLE
Fix nil panic in resourceDetails tool

### DIFF
--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -344,6 +344,9 @@ var rootCmd = &cobra.Command{
 				}
 				resourceType := opslevel.AliasOwnerTypeEnum(resourceTypeString)
 				resp, err := client.GetAliasableResource(resourceType, identifier)
+				if err != nil {
+					return newToolResult(nil, err)
+				}
 				switch v := resp.(type) {
 				case *opslevel.Service:
 					lastDeploy, err1 := v.GetLastDeploy(client, nil)


### PR DESCRIPTION
## Summary
- stop panics in `resourceDetails` when `GetAliasableResource` fails

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68502996fb148327b74e3014b00839d2