### PR TITLE
Allow the MCP server to start without authorization for inspection

### DIFF
--- a/.changes/unreleased/Changed-20250630-125123.yaml
+++ b/.changes/unreleased/Changed-20250630-125123.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Allow the MCP Server to start with no OPSLEVEL_API_TOKEN so it can be inspected and tested. Tools will not work without a valid OpsLevel API token.
+time: 2025-06-30T12:51:23.374588-07:00

--- a/src/cmd/client.go
+++ b/src/cmd/client.go
@@ -11,17 +11,22 @@ import (
 
 func NewGraphClient(version string, options ...opslevel.Option) *opslevel.Client {
 	timeout := time.Second * time.Duration(viper.GetInt("api-timeout"))
+	api_token := viper.GetString("api-token")
 	options = append(
 		options,
-		opslevel.SetAPIToken(viper.GetString("api-token")),
+		opslevel.SetAPIToken(api_token),
 		opslevel.SetURL(viper.GetString("api-url")),
 		opslevel.SetTimeout(timeout),
 		opslevel.SetUserAgentExtra(fmt.Sprintf("mcp-%s", version)),
 	)
 	client := opslevel.NewGQLClient(options...)
 
-	clientErr := client.Validate()
-	cobra.CheckErr(clientErr)
+	// If API token is provided, ensure it's valid in OpsLevel to notify the user.
+	// If no token is provided, just allow the server to start for inspection.
+	if api_token != "" {
+		clientErr := client.Validate()
+		cobra.CheckErr(clientErr)
+	}
 
 	return client
 }

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -126,8 +126,9 @@ var rootCmd = &cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		token := viper.GetString("api-token")
+		// Allow server to start even if token is missing
 		if token == "" {
-			return fmt.Errorf("no API token was found, use --api-token=XXX or the OPSLEVEL_API_TOKEN environment variable is required")
+			log.Warn().Msg("No API token was found. Tool requests will fail with 401 Unauthorized. Set an API token using --api-token=XXX or the OPSLEVEL_API_TOKEN environment variable.")
 		}
 
 		s := server.NewMCPServer(


### PR DESCRIPTION
### Problem

Third parties are unable to inspect the MCP server and its available tools without having a valid OpsLevel API token.

To better support aggregators [like Glama.ai](https://glama.ai/mcp/servers/@OpsLevel/opslevel-mcp), security scanners, contributors, etc. who might use [MCP Inspector](https://github.com/modelcontextprotocol/inspector) or other tools without a valid OpsLevel API key, we should allow this.

<img width="1031" alt="Screenshot 2025-07-02 at 9 31 12 AM" src="https://github.com/user-attachments/assets/ca5cb776-8933-476d-bb05-a4cfb1f90fd8" />

### Solution

Allow the server to start without authorizing, but still return 401 Unauthorized for any tool requests.

<img width="1009" alt="Screenshot 2025-07-02 at 9 30 51 AM" src="https://github.com/user-attachments/assets/a208dd54-d225-4803-bcdd-358d47faf452" />

With invalid token:

<img width="668" alt="Screenshot 2025-07-02 at 9 32 07 AM" src="https://github.com/user-attachments/assets/e76c5c98-2566-4320-88ac-874ad83583dc" />
<img width="595" alt="Screenshot 2025-07-02 at 9 32 59 AM" src="https://github.com/user-attachments/assets/ed3a410e-ea3b-4eda-9897-a7ae971ea628" />

With valid token:

<img width="595" alt="Screenshot 2025-07-02 at 9 33 41 AM" src="https://github.com/user-attachments/assets/2eab7413-55e4-4d55-af7b-f088ce46fd03" />


### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/opslevel-mcp/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change.
