### PR TITLE
Bump opslevel-go version to v2025.7.28

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.2
 
 require (
 	github.com/mark3labs/mcp-go v0.34.0
-	github.com/opslevel/opslevel-go/v2025 v2025.5.28
+	github.com/opslevel/opslevel-go/v2025 v2025.7.28
 	github.com/relvacode/iso8601 v1.6.0
 	github.com/rs/zerolog v1.34.0
 	github.com/spf13/cobra v1.9.1
@@ -55,4 +55,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/opslevel/opslevel-go/v2025 => ./submodules/opslevel-go
+// replace github.com/opslevel/opslevel-go/v2025 => ./submodules/opslevel-go

--- a/src/go.sum
+++ b/src/go.sum
@@ -79,6 +79,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/opslevel/moredefaults v0.0.0-20240529152742-17d1318a3c12 h1:OQZ3W8kbyCcdS8QUWFTnZd6xtdkfhdckc7Paro7nXio=
 github.com/opslevel/moredefaults v0.0.0-20240529152742-17d1318a3c12/go.mod h1:g2GSXVP6LO+5+AIsnMRPN+BeV86OXuFRTX7HXCDtYeI=
+github.com/opslevel/opslevel-go/v2025 v2025.7.28 h1:TWqr0kmViigS3f8HR8C5wX7Or5aTodElmuzVMDMlmzk=
+github.com/opslevel/opslevel-go/v2025 v2025.7.28/go.mod h1:Z2eSbXJ1Udn0gHm6z3Wi7a3sTMohtL5AlACl8YySoYs=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
Includes all of the component filtering and teams search we recently added, with no need for submodules.

https://github.com/OpsLevel/opslevel-go/releases/tag/v2025.7.28


### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/opslevel-mcp/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change.
