### PR TITLE
Indicate that component filter args must always be strings

### DIFF
--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -302,16 +302,17 @@ For complete reference:
 				if filterObj, exists := args["filter"]; exists && filterObj != nil {
 					// Marshal then unmarshal to our struct for type safety
 					filterBytes, marshalErr := json.Marshal(filterObj)
-					if marshalErr == nil {
-						var f componentFilter
-						if unmarshalErr := json.Unmarshal(filterBytes, &f); unmarshalErr == nil {
-							filterInput = &f
-						}
+					if marshalErr != nil {
+						return mcp.NewToolResultErrorFromErr("failed to marshal filter argument", marshalErr), nil
 					}
+					var f componentFilter
+					if unmarshalErr := json.Unmarshal(filterBytes, &f); unmarshalErr != nil {
+						return mcp.NewToolResultErrorFromErr("failed to unmarshal filter argument", unmarshalErr), nil
+					}
+					filterInput = &f
 				}
 
 				if filterInput != nil {
-					// Convert to ServiceFilterInput for the API
 					serviceFilter, convertErr := convertToServiceFilterInput(*filterInput)
 					if convertErr != nil {
 						return mcp.NewToolResultErrorFromErr("failed to convert filter", convertErr), nil


### PR DESCRIPTION
### Problem

Our components API only accepts strings for args, but agents will often try to pass numbers.
<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
Add a note to the input that Arg must always be string.
<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/opslevel-mcp/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change.
