### PR TITLE
Add WithStringEnumItems for accountMetadata tool

### DIFF
--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -416,7 +416,11 @@ For complete reference:
 			mcp.NewTool(
 				"accountMetadata",
 				mcp.WithDescription("Get metadata about the OpsLevel account including component types, tiers, & lifecycles, and maturity levels. Use this tool to retrieve relevant context (including indexes and ids for filters) before making other tool calls. Provide `types` whenever possible."),
-				mcp.WithArray("types", mcp.Description(fmt.Sprintf("Optional array of specific metadata types to fetch. Valid values: %s. If omitted, all metadata types will be fetched.", strings.Join(AllAccountMetadataStrings(), ", ")))),
+				mcp.WithArray(
+					"types", 
+					mcp.Description(fmt.Sprintf("Optional array of specific metadata types to fetch. Valid values: %s. If omitted, all metadata types will be fetched.", strings.Join(AllAccountMetadataStrings(), ", "))), 
+					mcp.WithStringEnumItems(AllAccountMetadataStrings()),
+				),
 				mcp.WithToolAnnotation(mcp.ToolAnnotation{
 					Title:           "Account Metadata in OpsLevel",
 					ReadOnlyHint:    &trueValue,


### PR DESCRIPTION
Resolves #

### Problem

OpenAI API enforces [OpenAPI array schema.
](https://swagger.io/docs/specification/v3_0/data-models/data-types/?sbsearch=array) On the other hand Bedrock doesn't enforce this.
Currently the tool schema for `accountMetadata` looks like this (without the `items` key):

``` 
{
    "type": "function",
    "function": {
      "name": "accountMetadata",
      "description": "Get metadata about the OpsLevel account including component types, tiers, & lifecycles, and maturity levels. Use this tool to retrieve relevant context (including indexes and ids for filters) before making other tool calls. Provide `types` whenever possible.",
      "parameters": {
        "properties": {
          "types": {
            "description": "Optional array of specific metadata types to fetch. Valid values: lifecycles, levels, tiers, componentTypes. If omitted, all metadata types will be fetched.",
            "type": "array"
          }
        },
        "type": "object",
        "additionalProperties": false,
        "required": ["types"]
      }
    }
}
```
When using the current MCP server implementation, the calls to OpenAI `chat_completions` endpoint will fail with the following error:
```openai.BadRequestError: Error code: 400 - {'error': {'message': "Invalid schema for function 'accountMetadata': In context=('properties', 'types'), array schema missing items.", 'type': 'invalid_request_error', 'param': 'tools[0].function.parameters', 'code': 'invalid_function_parameters'}}```

### Solution

Adding `mcp.WithStringEnumItems(AllAccountMetadataStrings()))` as argument in the `mcp.WithArray` higher order function populates the `items` key and restricts the possible values only to the enumeration of `AllAccountMetadataStrings()`:
```
{
  "type": "function",
  "function": {
    "name": "accountMetadata",
    "description": "Get metadata about the OpsLevel account including component types, tiers, & lifecycles, and maturity levels. Use this tool to retrieve relevant context (including indexes and ids for filters) before making other tool calls. Provide `types` whenever possible.",
    "parameters": {
      "properties": {
        "types": {
          "description": "Optional array of specific metadata types to fetch. Valid values: lifecycles, levels, tiers, componentTypes. If omitted, all metadata types will be fetched.",
          "type": "array",
          "items": {
            "type": "string",
            "enum": ["lifecycles", "levels", "tiers", "componentTypes"]
          }
        }
      },
      "type": "object",
      "additionalProperties": false,
      "required": ["types"]
    }
  }
}
```

### Checklist

- [X] I have run this code, and it appears to resolve the stated issue.
- [ ] Make a [changie](https://github.com/OpsLevel/opslevel-mcp/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change.
